### PR TITLE
version bump

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -3,6 +3,6 @@
 # https://github.com/terraform-linters/tflint-ruleset-aws/releases
 plugin "aws" {
     enabled = true
-    version = "0.13.0"
+    version = "0.13.2"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }


### PR DESCRIPTION
Version 0.13.1 fixes a lint error we're seeing here - https://github.com/loomhq/terraform-aws-vpc/runs/5758197512?check_suite_focus=true