### PR TITLE
Update to 0.17.0

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -3,6 +3,6 @@
 # https://github.com/terraform-linters/tflint-ruleset-aws/releases
 plugin "aws" {
   enabled = true
-  version = "0.16.1"
+  version = "0.17.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }


### PR DESCRIPTION
Getting an [error](https://github.com/loomhq/infra-terraform/runs/8235172475?check_suite_focus=true):
```
Failed to initialize plugins; TFLint is not compatible with this version of the "aws" plugin. A newer TFLint or plugin version may be required
```

Looks like 0.17.0 was just released [today](https://github.com/terraform-linters/tflint-ruleset-aws/releases/tag/v0.17.0)